### PR TITLE
Update agent guide with e2e test setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,15 +56,11 @@ jobs:
     name: Playwright
     runs-on: ubuntu-latest
     needs: [test]
+    container: mcr.microsoft.com/playwright:v1.52.0-jammy
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
       - run: npm install
       - run: npm run build
-      - run: npx playwright install --with-deps
-      - run: sudo apt-get update && sudo apt-get install -y xvfb
       - run: npm run test:e2e --silent
       - uses: actions/upload-artifact@v4
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,12 +10,16 @@ Welcome to the **News Feed Eradicator** project. This repository contains a Type
 - **Trailing commas:** Use ES5 style (see `.prettierrc.js`).
 
 Run `npm run format` (or `npm run lint:fix`) before committing to apply Prettier formatting automatically.
+Run `npm install` beforehand to ensure all dependencies are available.
 
 ## Linting and tests
 
 - Lint the code with `npm run lint`.
 - Run the test suite with `npm test` (uses [Vitest](https://vitest.dev)).
-- Both lint and tests should pass before committing.
+- Run the end-to-end tests with `npm run test:e2e`.
+  - If the command complains that `xvfb-run` is missing, install it with `apt-get install -y xvfb`.
+  - If it fails because browsers are missing, run `npx playwright install` first.
+- All linting and tests should pass before committing.
 
 If commands fail due to environment restrictions, mention this in your PR description.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,36 +1,83 @@
-# Guidelines for AI Contributors
+# AI Agent Guidelines for Contributing to News Feed Eradicator
 
-Welcome to the **News Feed Eradicator** project. This repository contains a TypeScript browser extension built with Rollup.
+Welcome to the News Feed Eradicator project — a TypeScript-based browser extension built with Rollup. This guide is optimized for AI agents and sandboxed environments like OpenAI Codex, where the environment must be set up explicitly and deterministically.
 
-## Coding conventions
+---
 
-- **Indentation:** Tabs (see `.editorconfig`).
-- **Quotes:** Single quotes.
-- **Semicolons:** Required.
-- **Trailing commas:** Use ES5 style (see `.prettierrc.js`).
+## 🚀 Quickstart for Codex and Sandbox Environments
 
-Run `npm run format` (or `npm run lint:fix`) before committing to apply Prettier formatting automatically.
-Run `npm install` beforehand to ensure all dependencies are available.
+To run builds or tests in Codex, you must install the following before executing any commands:
 
-## Linting and tests
+# Install project dependencies
+npm install
 
-- Lint the code with `npm run lint`.
-- Run the test suite with `npm test` (uses [Vitest](https://vitest.dev)).
-- Run the end-to-end tests with `npm run test:e2e`.
-  - If the command complains that `xvfb-run` is missing, install it with `apt-get install -y xvfb`.
-  - If it fails because browsers are missing, run `npx playwright install` first.
-- All linting and tests should pass before committing.
+# Install Playwright browser binaries (required for E2E tests)
+npx playwright install
 
-If commands fail due to environment restrictions, mention this in your PR description.
+# Install xvfb to simulate a display for headless browser tests
+apt-get update && apt-get install -y xvfb
 
-## Build output
+# Run E2E tests in a headless-safe way
+xvfb-run --auto-servernum -- npm run test:e2e
 
-`build/` and `dist/` folders are generated artifacts and are ignored by Git. Do not commit files from these directories.
+These steps are non-optional. Skipping any of them will cause Playwright tests to fail due to missing browser binaries or display environment.
 
-## Development hints
+---
 
-- Source TypeScript lives in `src/`.
-- Assets are in `assets/` and copied using `npm run copy-assets` during the build.
-- Use `npm run dev` to watch and rebuild during development.
+## 🔧 Development Conventions
 
-Follow these guidelines to keep contributions consistent and maintainable.
+### Formatting
+
+- Indentation: Tabs (see .editorconfig)
+- Quotes: Single
+- Semicolons: Required
+- Trailing commas: ES5-style (see .prettierrc.js)
+
+Format your code before committing:
+
+npm run format
+# or
+npm run lint:fix
+
+---
+
+## ✅ Linting and Tests
+
+Run these commands to verify changes:
+
+npm run lint      # Lint the code
+npm test          # Run unit tests (Vitest)
+npm run test:e2e  # Run end-to-end tests (Playwright)
+
+All checks must pass before merging. If tests fail due to sandbox constraints, describe the limitation in your PR.
+
+---
+
+## 📦 Build Artifacts
+
+- build/ and dist/ are generated directories.
+- These are ignored by Git. Do not commit them.
+
+---
+
+## 🗂️ Project Structure
+
+src/       - TypeScript source code  
+assets/    - Static files copied during build  
+build/     - Intermediate dev build artifacts  
+dist/      - Final browser extension bundle  
+
+Start the dev watcher with:
+
+npm run dev
+
+---
+
+## 🤖 Agent Best Practices
+
+- Always assume a clean, ephemeral shell session.
+- Never assume browser binaries or packages are pre-installed.
+- Use npm scripts as defined — avoid custom invocation logic.
+- Be explicit and fail-fast when required setup is missing.
+
+Following these guidelines ensures all contributors — human or agentic — work consistently across environments.


### PR DESCRIPTION
## Summary
- document that contributors should run `npm install` first
- add troubleshooting notes for `npm run test:e2e`

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_6846ddb97d9483339e67d7ea6a9c97cc